### PR TITLE
Add paranoia_update to prevent link table records from being permanen…

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -56,6 +56,47 @@ module Paranoia
     end
   end
 
+  def paranoia_update(attributes)
+    attributes = attributes.with_indifferent_access
+    object_class = self.class
+
+    has_many_through_associations = object_class.reflect_on_all_associations.select do |association|
+      association.is_a?(ActiveRecord::Reflection::ThroughReflection)
+    end
+
+    transaction do
+      run_callbacks(:update) do
+        has_many_through_associations.each do |association|
+          association_table_plural_name = association.source_reflection.plural_name.to_sym
+          association_key =
+            "#{object_class.reflect_on_association(association_table_plural_name).foreign_key.pluralize}"
+          link_table_class = association.through_reflection.klass
+          next if !attributes.key?(association_key) || !link_table_class.paranoid?
+
+          association_id_array = attributes[association_key].reject(&:blank?)
+          link_table_plural_name = association.through_reflection.plural_name.to_sym
+          object_key = "#{object_class.reflect_on_association(link_table_plural_name).foreign_key}"
+          object_primary_key = association.active_record.primary_key.to_sym
+
+          link_table_objects_to_be_soft_deleted =
+            link_table_class
+              .where(object_key => public_send(object_primary_key))
+              .where.not(association_key.singularize => association_id_array)
+          link_table_objects_to_be_soft_deleted.map(&:paranoia_destroy)
+        end
+
+        self.attributes = attributes
+        self.save
+      end
+    end
+  end
+  alias_method :update, :paranoia_update
+
+  def paranoia_update!(attributes)
+    paranoia_update(attributes) ||
+      raise(ActiveRecord::RecordNotDestroyed.new("Failed to update the record", self))
+  end
+
   def paranoia_destroy
     transaction do
       run_callbacks(:destroy) do

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -376,6 +376,27 @@ class ParanoiaTest < test_framework
     assert_equal 0, employee.employers.count
   end
 
+  def test_link_table_for_has_many_through_relationships_with_update_method_call
+    employer = Employer.create
+    employee_1 = Employee.create(id: 1)
+    employee_2 = Employee.create(id: 2)
+    employee_3 = Employee.create(id: 3)
+    employee_4 = Employee.create(id: 4)
+    employee_5 = Employee.create(id: 5)
+    job_1 = Job.create :employer => employer, :employee => employee_1
+    job_2 = Job.create :employer => employer, :employee => employee_2
+    job_3 = Job.create :employer => employer, :employee => employee_3
+    assert_equal 3, employer.jobs.count
+    assert_equal 3, employer.employees.count
+    assert_equal 1, employee_1.jobs.count
+    assert_equal 1, employee_2.employers.count
+
+    employer.update(employee_ids: [3,4,5])
+    assert_equal 5, Employee.count
+    assert_equal [3,4,5], Job.all.map(&:employee_id)
+    assert_equal [1,2], Job.deleted.map(&:employee_id)
+  end
+
   def test_delete_behavior_for_callbacks
     model = CallbackModel.new
     model.save


### PR DESCRIPTION
…tly deleted on the update/update_attributes method call.

I also have a spec on kaos to ensure this works.

I have tested it on the issue we had with the tokyo tote and it works i.e. the tagging records are only soft deleted.

Also, from the looks of the open PRs on the paranoia gem, I don't think our change will be accepted anytime soon.