### PR TITLE
Fix deprecation warning on with_indifferent_access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # paranoia Changelog
 
+## 2.4.2
+
+* Fix deprecation message on Hash#with_indifferent_access
+
 ## 2.4.1
 
 * [#435](https://github.com/rubysherpas/paranoia/pull/435) Monkeypatch activerecord relations to work with rails 5.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # paranoia Changelog
 
-## 2.4.2
+## 2.4.3
 
 * Fix deprecation message on Hash#with_indifferent_access
 

--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -57,7 +57,7 @@ module Paranoia
   end
 
   def paranoia_update(attributes)
-    attributes = attributes.with_indifferent_access
+    attributes = attributes.stringify_keys
     object_class = self.class
 
     has_many_through_associations = object_class.reflect_on_all_associations.select do |association|

--- a/lib/paranoia/version.rb
+++ b/lib/paranoia/version.rb
@@ -1,3 +1,3 @@
 module Paranoia
-  VERSION = '2.4.1'.freeze
+  VERSION = '2.4.2'.freeze
 end

--- a/lib/paranoia/version.rb
+++ b/lib/paranoia/version.rb
@@ -1,3 +1,3 @@
 module Paranoia
-  VERSION = '2.4.2'.freeze
+  VERSION = '2.4.3'.freeze
 end


### PR DESCRIPTION
In the later versions of Rails, the attributes that are passed in end up
being Parameter objects which will no longer respond to
with_indifferent_access however stringify_keys will still be available.